### PR TITLE
Don't crash on empty maps

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -388,6 +388,9 @@ dynamize_value({bs, Value}) when is_list(Value) ->
 
 dynamize_value({l, Value}) when is_list(Value) ->
     {<<"L">>, [[dynamize_value(V)] || V <- Value]};
+dynamize_value({m, []}) ->
+    %% jsx represents empty objects as [{}]
+    {<<"M">>, [{}]};
 dynamize_value({m, Value}) when is_list(Value) ->
     {<<"M">>, [dynamize_attr(Attr) || Attr <- Value]};
 
@@ -635,6 +638,9 @@ undynamize_value({<<"BS">>, Values}, _) ->
     [base64:decode(Value) || Value <- Values];
 undynamize_value({<<"L">>, List}, Opts) ->
     [undynamize_value(Value, Opts) || [Value] <- List];
+undynamize_value({<<"M">>, [{}]}, _Opts) ->
+    %% jsx returns [{}] for empty objects
+    [];
 undynamize_value({<<"M">>, Map}, Opts) ->
     [undynamize_attr(Attr, Opts) || Attr <- Map].
 


### PR DESCRIPTION
Although it is not possible to create an empty map at dynamodb, it is
possible to remove the last attribute in a map. When this happen,
erlcloud_ddb2 can't parse the results back and will crash.