### PR TITLE
Handle empty maps correctly

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -361,6 +361,9 @@ dynamize_value({bs, Value}) when is_list(Value) ->
 
 dynamize_value({l, Value}) when is_list(Value) ->
     {<<"L">>, [[dynamize_value(V)] || V <- Value]};
+dynamize_value({m, []}) ->
+    %% jsx represents empty objects as [{}]
+    {<<"M">>, [{}]};
 dynamize_value({m, Value}) when is_list(Value) ->
     {<<"M">>, [dynamize_attr(Attr) || Attr <- Value]};
 
@@ -608,6 +611,9 @@ undynamize_value({<<"BS">>, Values}, _) ->
     [base64:decode(Value) || Value <- Values];
 undynamize_value({<<"L">>, List}, Opts) ->
     [undynamize_value(Value, Opts) || [Value] <- List];
+undynamize_value({<<"M">>, [{}]}, _Opts) ->
+    %% jsx returns [{}] for empty objects
+    [];
 undynamize_value({<<"M">>, Map}, Opts) ->
     [undynamize_attr(Attr, Opts) || Attr <- Map].
 


### PR DESCRIPTION
In order to create/read empty maps from dynamodb, we need to convert it correctly to empty objects for jsx.

The only changes here should be specs, no code whatsoever