### PR TITLE
Improve Erlang 19's Dialyzer results for erlcloud_ddb2

### DIFF
--- a/include/erlcloud_ddb2.hrl
+++ b/include/erlcloud_ddb2.hrl
@@ -1,14 +1,14 @@
 -record(ddb2_error,
-        {attempt :: pos_integer(),
-         error_type :: ddb | http | httpc,
-         should_retry :: boolean(),
-         reason :: term(),
-         request_headers :: [{string(), string()}],
-         request_body :: jsx:json_text(),
-         response_status :: pos_integer(),
-         response_status_line :: string(),
-         response_headers :: [{string(), string()}],
-         response_body :: binary()
+        {attempt :: undefined | pos_integer(),
+         error_type :: undefined | ddb | http | httpc,
+         should_retry :: undefined | boolean(),
+         reason :: undefined | term(),
+         request_headers :: undefined | [{string(), string()}],
+         request_body :: undefined | jsx:json_text(),
+         response_status :: undefined | pos_integer(),
+         response_status_line :: undefined | string(),
+         response_headers :: undefined | [{string(), string()}],
+         response_body :: undefined | binary()
         }).
 
 -type date_time() :: number().


### PR DESCRIPTION
Make it possible for Dialyzer (Erlang 19) to conclude generic {error, term()} errors can be returned on misc. erlcloud\_ddb2 calls.

If we don't explicitly declare that #ddb2\_error{} fields might be undefined, Dialyzer will mark the DDBError binding initialization on erlcloud_ddb_impl:request\_and\_retry/4 (line 198 as of 988528d7) as invalid due to all the missing fields. This, in its turn, invalidates analysis of the remaining pipeline of result processing, which in its turn blinds Dialyzer to the fact that errors other than "{socket_error,\_}" and "{http\_error,\_,\_,\_}}" can and will be returned (e.g. conditional check failures.)